### PR TITLE
Updating to ANNA 2.0 + minor fixes

### DIFF
--- a/syntaxes/anna.tmLanguage.json
+++ b/syntaxes/anna.tmLanguage.json
@@ -33,7 +33,7 @@
 		"labels": {
 			"patterns": [
 				{
-					"match": "(&)([a-zA-Z0-9_]+)($|\\s*)",
+					"match": "(&)([a-zA-Z0-9_]+)($|\\S*)",
 					"name": "entity.name.type.anna"
 				},
 				{

--- a/syntaxes/anna.tmLanguage.json
+++ b/syntaxes/anna.tmLanguage.json
@@ -26,7 +26,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.anna",
-					"match": "\\b(add|sub|and|or|not|shf|lli|lui|lw|sw|bez|bgz|addi|jalr|in|out)\\b"
+					"match": "\\b(add|sub|and|or|not|shf|lli|lui|lw|sw|beq|bne|bgt|bge|blt|ble|addi|jalr|in|out)\\b"
 				}
 			]
 		},
@@ -62,7 +62,7 @@
 			"match": "(r[0-7])(\\S|$)?",
 			"captures": {
 				"1": {
-					"name": "support.variable.annna"
+					"name": "support.variable.anna"
 				}
 			}
 		},


### PR DESCRIPTION
Thanks for making this :D

### Updates keyword matching to include new keywords in 2.0
```diff
- bez bgz
+ beq bne bgt bge blt ble
```
### Fixes whitespace between labels and comments when used as addresses

#### Current
<pre><code>foo r0 r0 <ins>&label        </ins># comment</pre></code>
#### Expected
<pre><code>foo r0 r0 <ins>&label</ins>        # comment</pre></code>

#### Fixed spelling error on `support.variable.annna`